### PR TITLE
fix: working directory for the generate version script must be the current workspace dir

### DIFF
--- a/fetch-commit-version/action.yml
+++ b/fetch-commit-version/action.yml
@@ -59,11 +59,10 @@ runs:
   - name: Fetch commit version
     id: fetch-commit-version
     shell: bash
-    working-directory: ${{ github.action_path }}/..
     env:
       GITHUB_TOKEN: ${{ inputs.github-token }}
     run: |
-      COMMIT_VERSION=$(uv run python -m github_semver.commit_version --commit-sha "${{ steps.commit-sha.outputs.sha }}" --artifact-name "${{ inputs.artifact-name }}" --workflow-name "${{ inputs.workflow-name }}")
+      COMMIT_VERSION=$(uv run --project ${{ github.action_path }}/.. python -m github_semver.commit_version --commit-sha "${{ steps.commit-sha.outputs.sha }}" --artifact-name "${{ inputs.artifact-name }}" --workflow-name "${{ inputs.workflow-name }}")
       echo "$COMMIT_VERSION" > version
       echo "version=$COMMIT_VERSION" >> $GITHUB_OUTPUT
       echo "COMMIT_VERSION=$COMMIT_VERSION" >> $GITHUB_ENV

--- a/generate-version/action.yml
+++ b/generate-version/action.yml
@@ -39,12 +39,11 @@ runs:
   - name: Generate version
     id: generate-version
     shell: bash
-    working-directory: ${{ github.action_path }}/..
     env:
       BUILD_RC_SEMVER: ${{ inputs.build-rc-semver }}
       REPO_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     run: |
-      SEMVER_VERSION=$(uv run python -m github_semver.run_semver)
+      SEMVER_VERSION=$(uv run --project ${{ github.action_path }}/.. python -m github_semver.run_semver)
       echo "$SEMVER_VERSION" > version
       echo "version=$SEMVER_VERSION" >> $GITHUB_OUTPUT
       echo "SEMVER_VERSION=$SEMVER_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
If we use the path of this action, then the git repo cannot be resolved and the version scripts will throw git errors
