### PR TITLE
feat: wait until main pipeline is finished instead of failing when fetching commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       id: fetch-commit-version
       uses: ./fetch-commit-version
       env:
-        LIST_ALL_WORKFLOWS: "true"  # To be able to retrieve artifacts from the current workflow run
+        ALLOW_UNFINISHED_WORKFLOWS: "true"  # To be able to retrieve artifacts from the current workflow run
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
With this change, you can now immediately after merging a PR create a release as the fetch-commit-version action will now wait until the pipeline is finished.
