### PR TITLE
chore: allow v prefixed tags for tag detection

### DIFF
--- a/github_semver/run_semver.py
+++ b/github_semver/run_semver.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def _retrieve_latest_tag_from_git() -> str | None:
     # raw tag is a line which is 'tab' separated, with hash on the left
-    # tag on the right. tag is in a refs/tags/0.0.x format.
+    # tag on the right. tag is in a refs/tags/0.0.x or refs/tags/v0.0.x format.
     raw_output = subprocess.check_output(
         "git ls-remote --refs --tags --sort='-v:refname'",
         shell=True,
@@ -20,7 +20,8 @@ def _retrieve_latest_tag_from_git() -> str | None:
     logger.debug(f"shell output is: {raw_output}")
     tag_lines = raw_output.splitlines()
     for tag in tag_lines:
-        if semver_match := re.search(r"refs/tags/([0-9]+\..*)", tag):
+        # an optional leading 'v' is stripped so 0.0.1 and v0.0.1 both match.
+        if semver_match := re.search(r"refs/tags/v?([0-9]+\..*)", tag):
             return semver_match.group(1)
 
     return None

--- a/tests/test_run_semver.py
+++ b/tests/test_run_semver.py
@@ -91,6 +91,25 @@ def test_when_run_on_default_branch_patch_bump_based_on_last_tag(
     clear=True,
 )
 @mock.patch.object(subprocess, "check_output")
+def test_when_tag_has_v_prefix_it_is_recognized_and_bumped(mock_check_output, capsys):
+    mock_check_output.return_value = b"b2984df042ba025c1f46f74eaea18945fc504e7a\trefs/tags/v1.0.0\nfcc84d34053e580507cb79583587b37812a21e10\trefs/tags/v0.0.1\n"
+
+    main()
+    assert capsys.readouterr().out == "1.0.1-rc.1+abababa\n"
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "GITHUB_SHA": "abababababababababababababababababababab",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_NAME": "main",
+        "REPO_DEFAULT_BRANCH": "main",
+        "GITHUB_RUN_NUMBER": "1",
+    },
+    clear=True,
+)
+@mock.patch.object(subprocess, "check_output")
 def test_when_run_on_default_branch_without_tag_bump_to_0_0_2_rc(
     mock_check_output, capsys
 ):


### PR DESCRIPTION
fix semver handling for v<x.x.x> tags