### PR TITLE
fix(commit-version): wait for workflow run to appear for the commit

### DIFF
--- a/github_semver/commit_version.py
+++ b/github_semver/commit_version.py
@@ -141,7 +141,7 @@ def _make_request_with_retry(
 
 def _wait_for_workflow_completion(
     workflow_run: dict[str, Any],
-    max_wait_time: int = MAX_WAIT_TIME,
+    max_wait_time: float = MAX_WAIT_TIME,
 ) -> dict[str, Any] | None:
     """
     Wait for a specific workflow run to complete successfully.
@@ -197,6 +197,11 @@ def get_last_successful_workflow_for_commit(
     Always fetches both successful and in-progress workflows. If DO_NOT_WAIT_FOR_SUCCESS
     is set, immediately returns in-progress workflow. Otherwise, waits for them to complete.
 
+    When waiting and no run is associated with the commit yet, polls until one appears
+    or MAX_WAIT_TIME is reached. The commit-filtered runs endpoint lags behind run
+    creation, so a run triggered alongside the caller may not be listed on the first
+    request even though it exists.
+
     Args:
         commit_sha (str): full sha to search workflow runs for.
         workflow_name (str, optional): name of the workflow to filter by.
@@ -213,27 +218,34 @@ def get_last_successful_workflow_for_commit(
     else:
         logger.info("Will wait for workflows to complete successfully")
 
-    # Fetch all workflows and filter out failed ones
-    all_workflow_runs = _fetch_all_workflow_runs(commit_sha)
+    start_time = time.time()
+    while True:
+        # Fetch all workflows, filter out failed ones, then narrow by name.
+        all_workflow_runs = _fetch_all_workflow_runs(commit_sha)
+        if workflow_name:
+            all_workflow_runs = _filter_workflows_by_name(
+                all_workflow_runs, workflow_name
+            )
 
-    # Handle case when no workflows are found
-    if not all_workflow_runs:
-        return _handle_no_workflows_found(commit_sha, workflow_name)
+        if all_workflow_runs:
+            # Sort workflow runs by ID (latest first), then pick the best one.
+            sorted_runs = sorted(all_workflow_runs, key=lambda x: x["id"], reverse=True)
+            remaining = max(0.0, MAX_WAIT_TIME - (time.time() - start_time))
+            return _find_best_workflow_run(
+                sorted_runs,
+                wait_for_success=wait_for_success,
+                max_wait_time=remaining,
+            )
 
-    # Filter by workflow name if specified
-    if workflow_name:
-        all_workflow_runs = _filter_workflows_by_name(all_workflow_runs, workflow_name)
-        if not all_workflow_runs:
+        # No run is associated with the commit yet.
+        if not wait_for_success or time.time() - start_time >= MAX_WAIT_TIME:
             return _handle_no_workflows_found(commit_sha, workflow_name)
 
-    # Sort workflow runs by ID (latest first)
-    sorted_runs = sorted(all_workflow_runs, key=lambda x: x["id"], reverse=True)
-
-    # Find the best workflow run based on configuration
-    return _find_best_workflow_run(
-        sorted_runs,
-        wait_for_success=wait_for_success,
-    )
+        logger.info(
+            f"No workflow run listed for commit {commit_sha} yet, "
+            f"retrying in {WORKFLOW_POLL_INTERVAL}s"
+        )
+        time.sleep(WORKFLOW_POLL_INTERVAL)
 
 
 def _fetch_all_workflow_runs(
@@ -297,6 +309,7 @@ def _find_best_workflow_run(
     sorted_runs: list[dict[str, Any]],
     *,
     wait_for_success: bool,
+    max_wait_time: float = MAX_WAIT_TIME,
 ) -> dict[str, Any] | None:
     """Find the best workflow run based on the current configuration."""
     if not sorted_runs:
@@ -333,7 +346,7 @@ def _find_best_workflow_run(
         logger.info(
             f"Latest workflow run {latest_run['id']} has not finished yet, waiting for completion..."
         )
-        return _wait_for_workflow_completion(latest_run)
+        return _wait_for_workflow_completion(latest_run, max_wait_time)
 
     logger.info(
         f"No successful workflow runs found. Latest run {latest_run['id']} has status: {status}, conclusion: {conclusion}"

--- a/tests/test_commit_version.py
+++ b/tests/test_commit_version.py
@@ -431,3 +431,79 @@ def test_waits_for_latest_workflow_only(mock_sleep, mock_get):  # noqa: ARG001
     # Second call should be to the specific workflow run endpoint
     second_call_url = mock_get.call_args_list[1][0][0]
     assert f"/actions/runs/{LATEST_IN_PROGRESS_WORKFLOW_ID}" in second_call_url
+
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_REPOSITORY": "owner/repo", "GITHUB_TOKEN": "test_token"},
+    clear=True,
+)
+@patch("github_semver.commit_version.requests.get")
+@patch("github_semver.commit_version.time.sleep")
+def test_waits_for_workflow_run_to_appear(mock_sleep, mock_get):
+    # The commit-filtered runs endpoint lags behind run creation, so the run
+    # triggered alongside the caller is not listed on the first request.
+    empty_response = MagicMock()
+    empty_response.status_code = 200
+    empty_response.headers = {"Link": None}
+    empty_response.raise_for_status.return_value = None
+    empty_response.json.return_value = {"workflow_runs": []}
+
+    # On the next poll the run is listed, still in progress.
+    appeared_response = MagicMock()
+    appeared_response.status_code = 200
+    appeared_response.headers = {"Link": None}
+    appeared_response.raise_for_status.return_value = None
+    appeared_response.json.return_value = {
+        "workflow_runs": [
+            {
+                "id": LATEST_IN_PROGRESS_WORKFLOW_ID,
+                "name": "build",
+                "status": "in_progress",
+                "conclusion": None,
+            },
+        ]
+    }
+
+    # Polling that specific run shows it completed successfully.
+    completed_response = MagicMock()
+    completed_response.status_code = 200
+    completed_response.raise_for_status.return_value = None
+    completed_response.json.return_value = {
+        "id": LATEST_IN_PROGRESS_WORKFLOW_ID,
+        "name": "build",
+        "status": "completed",
+        "conclusion": "success",
+    }
+
+    mock_get.side_effect = [empty_response, appeared_response, completed_response]
+
+    result = get_last_successful_workflow_for_commit("abc123", workflow_name="build")
+
+    assert result is not None
+    assert result["id"] == LATEST_IN_PROGRESS_WORKFLOW_ID
+    # Slept once while waiting for the run to appear.
+    mock_sleep.assert_called_once()
+
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_REPOSITORY": "owner/repo", "GITHUB_TOKEN": "test_token"},
+    clear=True,
+)
+@patch("github_semver.commit_version.MAX_WAIT_TIME", 0)
+@patch("github_semver.commit_version.requests.get")
+@patch("github_semver.commit_version.time.sleep")
+def test_returns_none_when_no_run_appears_before_timeout(mock_sleep, mock_get):
+    # No run is ever listed for the commit; the wait must be bounded.
+    empty_response = MagicMock()
+    empty_response.status_code = 200
+    empty_response.headers = {"Link": None}
+    empty_response.raise_for_status.return_value = None
+    empty_response.json.return_value = {"workflow_runs": []}
+    mock_get.return_value = empty_response
+
+    result = get_last_successful_workflow_for_commit("abc123", workflow_name="build")
+
+    assert result is None
+    mock_sleep.assert_not_called()


### PR DESCRIPTION
`fetch-commit-version` could fail when run alongside the build it depends on (e.g. a preview-deploy job triggered by the same event): GitHub's commit-filtered runs endpoint lags behind run creation, so the query returned no runs and the action exited immediately instead of waiting. It now polls until a run appears or `MAX_WAIT_TIME` is reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)